### PR TITLE
change C99 syntax not supported by C++

### DIFF
--- a/src/ssw.h
+++ b/src/ssw.h
@@ -177,15 +177,15 @@ static inline char cigar_int_to_op (uint32_t cigar_int)
 {
 	uint8_t letter_code = cigar_int & 0xfU;
 	static const char map[] = {
-		[0] = 'M',
-		[1] = 'I',
-		[2] = 'D',
-		[3] = 'N',
-		[4] = 'S',
-		[5] = 'H',
-		[6] = 'P',
-		[7] = '=',
-		[8] = 'X',
+		'M',
+		'I',
+		'D',
+		'N',
+		'S',
+		'H',
+		'P',
+		'=',
+		'X',
 	};
 
 	if (letter_code >= (sizeof(map)/sizeof(map[0]))) {


### PR DESCRIPTION
This C99 syntax feature and GNU C extension of C89 syntax breaks g++. See http://gcc.gnu.org/onlinedocs/gcc-4.1.2/gcc/Designated-Inits.html for details. There is no need for the array index initializers since the initialization here is straightforward.
