### PR TITLE
Improved cigar operations

### DIFF
--- a/src/ssw.c
+++ b/src/ssw.c
@@ -607,7 +607,7 @@ static cigar* banded_sw (const int8_t* ref,
 				temp1 = i == 0 ? -weight_gapO : h_b[e] - weight_gapO;
 				temp2 = i == 0 ? -weight_gapE : e_b[e] - weight_gapE;
 				e_b[u] = temp1 > temp2 ? temp1 : temp2;
-				fprintf(stderr, "de: %d\twidth_d: %d\treadLen: %d\ts2:%d\n", de, width_d, readLen, s2);
+				fprintf(stderr, "de: %d\twidth_d: %d\treadLen: %d\ts2:%lu\n", de, width_d, readLen, s2);
 				direction_line[de] = temp1 > temp2 ? 3 : 2;
 
 				temp1 = h_c[b] - weight_gapO;
@@ -873,30 +873,12 @@ void align_destroy (s_align* a) {
 	free(a);
 }
 
-char cigar_int_to_op (uint32_t cigar_int)
-{
-	uint8_t letter_code = cigar_int & 0xfU;
-	static const char map[] = {
-		'M',
-		'I',
-		'D',
-		'N',
-		'S',
-		'H',
-		'P',
-		'=',
-		'X',
-	};
-
-	if (letter_code >= (sizeof(map)/sizeof(map[0]))) {
-		return 'M';
-	}
-
-	return map[letter_code];
+inline char cigar_int_to_op(uint32_t cigar_int) {
+	return cigar_int > 8 ? 'M': MAPSTR[cigar_int];
 }
 
-uint32_t cigar_int_to_len (uint32_t cigar_int)
+
+inline uint32_t cigar_int_to_len (uint32_t cigar_int)
 {
-	uint32_t res = cigar_int >> 4;
-	return res;
+	return cigar_int >> BAM_CIGAR_SHIFT;
 }

--- a/src/ssw.c
+++ b/src/ssw.c
@@ -874,7 +874,7 @@ void align_destroy (s_align* a) {
 }
 
 inline char cigar_int_to_op(uint32_t cigar_int) {
-	return cigar_int > 8 ? 'M': MAPSTR[cigar_int];
+	return UNLIKELY((cigar_int & 0xfU) > 8) ? 'M': MAPSTR[cigar_int & 0xfU];
 }
 
 

--- a/src/ssw.h
+++ b/src/ssw.h
@@ -140,16 +140,16 @@ static inline uint32_t to_cigar_int (uint32_t length, char op_letter)
 		case 'M': /* alignment match (can be a sequence match or mismatch */
 		default:
 			return length << BAM_CIGAR_SHIFT;
-		case 'I': /* insertion to the reference */
-			return (length << BAM_CIGAR_SHIFT) | (1u);
-		case 'D': /* deletion from the reference */
-			return (length << BAM_CIGAR_SHIFT) | (2u);
-		case 'N': /* skipped region from the reference */
-			return (length << BAM_CIGAR_SHIFT) | (3u);
 		case 'S': /* soft clipping (clipped sequences present in SEQ) */
 			return (length << BAM_CIGAR_SHIFT) | (4u);
+		case 'D': /* deletion from the reference */
+			return (length << BAM_CIGAR_SHIFT) | (2u);
+		case 'I': /* insertion to the reference */
+			return (length << BAM_CIGAR_SHIFT) | (1u);
 		case 'H': /* hard clipping (clipped sequences NOT present in SEQ) */
 			return (length << BAM_CIGAR_SHIFT) | (5u);
+		case 'N': /* skipped region from the reference */
+			return (length << BAM_CIGAR_SHIFT) | (3u);
 		case 'P': /* padding (silent deletion from padded reference) */
 			return (length << BAM_CIGAR_SHIFT) | (6u);
 		case '=': /* sequence match */

--- a/src/ssw.h
+++ b/src/ssw.h
@@ -139,23 +139,23 @@ static inline uint32_t to_cigar_int (uint32_t length, char op_letter)
 	switch (op_letter) {
 		case 'M': /* alignment match (can be a sequence match or mismatch */
 		default:
-			return length << 4;
+			return length << BAM_CIGAR_SHIFT;
 		case 'I': /* insertion to the reference */
-			return (length << 4) | (1u);
+			return (length << BAM_CIGAR_SHIFT) | (1u);
 		case 'D': /* deletion from the reference */
-			return (length << 4) | (2u);
+			return (length << BAM_CIGAR_SHIFT) | (2u);
 		case 'N': /* skipped region from the reference */
-			return (length << 4) | (3u);
+			return (length << BAM_CIGAR_SHIFT) | (3u);
 		case 'S': /* soft clipping (clipped sequences present in SEQ) */
-			return (length << 4) | (4u);
+			return (length << BAM_CIGAR_SHIFT) | (4u);
 		case 'H': /* hard clipping (clipped sequences NOT present in SEQ) */
-			return (length << 4) | (5u);
+			return (length << BAM_CIGAR_SHIFT) | (5u);
 		case 'P': /* padding (silent deletion from padded reference) */
-			return (length << 4) | (6u);
+			return (length << BAM_CIGAR_SHIFT) | (6u);
 		case '=': /* sequence match */
-			return (length << 4) | (7u);
+			return (length << BAM_CIGAR_SHIFT) | (7u);
 		case 'X': /* sequence mismatch */
-			return (length << 4) | (8u);
+			return (length << BAM_CIGAR_SHIFT) | (8u);
 	}
 	return (uint32_t)-1; // This never happens
 }

--- a/src/ssw.h
+++ b/src/ssw.h
@@ -20,6 +20,11 @@
 extern "C" {
 #endif	// __cplusplus
 
+#define MAPSTR "MIDNSHP=X"
+#ifndef BAM_CIGAR_SHIFT
+#define BAM_CIGAR_SHIFT 4
+#endif
+
 
 /*!	@typedef	structure of the query profile	*/
 struct _profile;
@@ -131,43 +136,30 @@ void align_destroy (s_align* a);
 */
 static inline uint32_t to_cigar_int (uint32_t length, char op_letter)
 {
-	uint32_t res;
-	uint8_t op_code;
-
 	switch (op_letter) {
 		case 'M': /* alignment match (can be a sequence match or mismatch */
 		default:
-			op_code = 0;
-			break;
+			return length << 4;
 		case 'I': /* insertion to the reference */
-			op_code = 1;
-			break;
+			return (length << 4) | (1u);
 		case 'D': /* deletion from the reference */
-			op_code = 2;
-			break;
+			return (length << 4) | (2u);
 		case 'N': /* skipped region from the reference */
-			op_code = 3;
-			break;
+			return (length << 4) | (3u);
 		case 'S': /* soft clipping (clipped sequences present in SEQ) */
-			op_code = 4;
-			break;
+			return (length << 4) | (4u);
 		case 'H': /* hard clipping (clipped sequences NOT present in SEQ) */
-			op_code = 5;
-			break;
+			return (length << 4) | (5u);
 		case 'P': /* padding (silent deletion from padded reference) */
-			op_code = 6;
-			break;
+			return (length << 4) | (6u);
 		case '=': /* sequence match */
-			op_code = 7;
-			break;
+			return (length << 4) | (7u);
 		case 'X': /* sequence mismatch */
-			op_code = 8;
-			break;
+			return (length << 4) | (8u);
 	}
-
-	res = (length << 4) | op_code;
-	return res;
+	return (uint32_t)-1; // This never happens
 }
+
 
 /*!	@function		Extract CIGAR operation character from CIGAR 32-bit unsigned integer
 	@param	cigar_int	32-bit unsigned integer, representing encoded CIGAR operation and length


### PR DESCRIPTION
I've tested that this still works in python mode, which was the reason for making the cigar operation functions not inline.

I haven't benchmarked the performance difference, but switching the existing code for more bit operations, fewer assigned temporary variables, and a string constant for the map can't be slower than the current impementation.

I also modified one string format parameter. (I replaced %i with%lu to eliminate the compiler warning.)