### PR TITLE
fix make java, add gitignore

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,12 @@
+*.*~
+example_c
+example_cpp
+libssw.so
+libsswjni.so
+ssw.jar
+ssw.o
+ssw/Aligner.class
+ssw/Alignment.class
+ssw/Example.class
+ssw_cpp.o
+ssw_test 

--- a/src/Makefile
+++ b/src/Makefile
@@ -41,7 +41,7 @@ $(JAVA_JAR): $(JAVA_OBJ)
 	jar cvfe $@ ssw.Example $^
 
 %.class: %.java
-	javac $<
+	javac -cp ./ $<
 	
 ssw.o: ssw.c ssw.h
 	$(CC) -c -o $@ $< $(CFLAGS)


### PR DESCRIPTION
fixes make java (see https://github.com/mengyao/Complete-Striped-Smith-Waterman-Library/issues/25) - without this change `make java` does not work on my RedHat 6.7 

added .gitignore to include generate files