### PR TITLE
enable building on non SSE2 CPUs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/simde"]
+	path = src/simde
+	url = https://github.com/nemequ/simde-no-tests

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 CC = gcc
 CXX = g++
-CFLAGS := -Wall -pipe -O2
+CFLAGS += -Wall -pipe -O3 -I.
 CXXFLAGS := $(CFLAGS)
 LOBJS = ssw.o
 LCPPOBJS = ssw_cpp.o

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,6 @@
 
 #include <stdlib.h>
 #include <stdint.h>
-#include <emmintrin.h>
 #include <zlib.h>
 #include <stdio.h>
 #include <time.h>

--- a/src/ssw.c
+++ b/src/ssw.c
@@ -67,7 +67,8 @@
  */
 
 //#include <nmmintrin.h>
-#include <emmintrin.h>
+#define SIMDE_ENABLE_NATIVE_ALIASES
+#include <simde/x86/sse2.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/ssw.h
+++ b/src/ssw.h
@@ -14,7 +14,6 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
-#include <emmintrin.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Fixes #68 

This change is already included in the Debian package of this library, as seen at https://packages.debian.org/sid/libssw0