### PR TITLE
Fix Back Trace Error in Alignment

### DIFF
--- a/src/ssw.c
+++ b/src/ssw.c
@@ -674,7 +674,7 @@ static cigar* banded_sw (const int8_t* ref,
 	l = 0;	// record length of current cigar
 	op = prev_op = 'M';
 	temp2 = 2;	// h
-	while (LIKELY(i > 0)) {
+	while (LIKELY(i >=0 & j >0)) {
 		set_d(temp1, band_width, i, j, temp2);
 		switch (direction_line[temp1]) {
 			case 1:


### PR DESCRIPTION
We encountered a bug in the library, which can be reproduced as follows: Given this reference and query files:

```
>ref
AGTGTAAACTGTACCTGATGGCTAA

```

```
>probe
ATGTAAACTGTACCTGATGGCTAA
```

The alignment produced by this command is clearly incorrect, though the alignment score appears correct for the "right" alignment:

```
python pyssw.py ref.fa query.fa -c -m 3 -x 2 -o 2 -e 1
target_name: ref
query_name: probe
optimal_alignment_score: 70	suboptimal_alignment_score: 22	strand: +	target_begin: 1	target_end: 25	query_begin: 1	query_end: 24

Target:       1	AGTGTAAACTGTACCTGATGGCTA	24
               	|****||******|*****|***|
Query:        1	ATGTAAACTGTACCTGATGGCTAA	24
```

Making this change produces the correct alignment, as it appeared the issue was due to the traceback terminating too early:

```
target_name: ref
query_name: probe
optimal_alignment_score: 70	suboptimal_alignment_score: 22	strand: +	target_begin: 1	target_end: 25	query_begin: 1	query_end: 24

Target:       1	AGTGTAAACTGTACCTGATGGCTAA	25
               	| |||||||||||||||||||||||
Query:        1	A-TGTAAACTGTACCTGATGGCTAA	24
```

I didn't have time to audit the code thoroughly enough to know if this solution was always valid, but it appeared to work on several tested examples.