### PR TITLE
Modernize cpp

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,7 @@
-CC = gcc
-CXX = g++
-CFLAGS += -Wall -pipe -O2
-#CFLAGS += -Wall -pipe -g -fsanitize=address	# for debug
-CXXFLAGS := $(CFLAGS)
+CFLAGS ?= -O2 -pipe
+CFLAGS += -Wall -pedantic
+#CFLAGS += -Og -g -fsanitize=address	# for debug
+CXXFLAGS ?= $(CFLAGS)
 LOBJS = ssw.o
 LCPPOBJS = ssw_cpp.o
 PROG = ssw_test
@@ -16,13 +15,13 @@ JAVA_OBJ = ssw/Aligner.class ssw/Alignment.class ssw/Example.class
 
 .PHONY: all default java clean
 
-default: $(PROG) $(EXAMPLE) $(EXAMPLE_CPP) $(LIB) 
+default: $(PROG) $(EXAMPLE) $(EXAMPLE_CPP) $(LIB)
 core: $(PROG)
 java: java_home $(JAVA_JAR) $(JAVA_LIB)
 all: default java
 
 $(LIB): ssw.c ssw.h
-	$(CC) $(CFLAGS) -fPIC -shared -rdynamic -o $@ $<
+	$(CC) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) -fPIC -shared -rdynamic -o $@ $<
 
 $(PROG): main.c kseq.h
 
@@ -30,14 +29,14 @@ $(EXAMPLE): example.c
 
 ifdef __arm__ # (M1)
 $(PROG) $(EXAMPLE): $(LOBJS)
-	$(CC) -o $@ $(filter-out %.h,$^) $(CFLAGS) $(LDFLAGS) -lm -lz -march=armv8-a+fp+simd+crypto+crc
+	$(CC) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) -o $@ $(filter-out %.h,$^) -lm -lz -march=armv8-a+fp+simd+crypto+crc
 else # x86(Intel)
 $(PROG) $(EXAMPLE): $(LOBJS)
-	$(CC) -o $@ $(filter-out %.h,$^) $(CFLAGS) $(LDFLAGS) -lm -lz
+	$(CC) $(LDFLAGS) $(CPPFLAGS) $(CFLAGS) -o $@ $(filter-out %.h,$^) -lm -lz
 endif
 
 $(EXAMPLE_CPP): example.cpp $(LOBJS) $(LCPPOBJS)
-	$(CXX) -o $@ $^ $(CXXFLAGS) $(LDFLAGS) -lm -lz
+	$(CXX) $(LDFLAGS) $(CPPFLAGS) $(CXXFLAGS) -o $@ $^ -lm -lz
 
 $(JAVA_LIB): sswjni.c ssw.c ssw.h
 	$(CC) $(CFLAGS) $(JAVA_INLCUDES) -fPIC -shared -rdynamic -o $@ $< ssw.c 
@@ -55,10 +54,10 @@ ifndef JAVA_HOME
 endif
 
 ssw.o: ssw.c ssw.h
-	$(CC) -c -o $@ $< $(CFLAGS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
 
 ssw_cpp.o: ssw_cpp.cpp ssw_cpp.h ssw.h
-	$(CXX) -c -o $@ $< $(CXXFLAGS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c -o $@ $<
 
 clean:
 	-rm -f $(LOBJS) $(LCPPOBJS) $(PROG) $(LIB) $(EXAMPLE) $(EXAMPLE_CPP) $(JAVA_LIB) $(JAVA_JAR) $(JAVA_OBJ) *~ 

--- a/src/example.cpp
+++ b/src/example.cpp
@@ -8,22 +8,21 @@
 // Last revision by Mengyao Zhao on 2023-Apr-21
 // ==========================
 
+#include <algorithm>
 #include <iostream>
-#include <string.h>
+#include <string>
 
 #include "ssw_cpp.h"
 
-using std::string;
 using std::cout;
 using std::endl;
 
 static void PrintAlignment(const StripedSmithWaterman::Alignment& alignment);
 
 int main() {
-  const string ref   = "CAGCCTTTCTGACCCGGAAATCAAAATAGGCACAACAAA";
-  const string query = "CTGAGCCGGTAAATC";
-  int32_t maskLen = strlen(query.c_str())/2;
-  maskLen = maskLen < 15 ? 15 : maskLen;
+  const std::string ref("CAGCCTTTCTGACCCGGAAATCAAAATAGGCACAACAAA");
+  const std::string query("CTGAGCCGGTAAATC");
+  const int32_t     maskLen = std::max(query.size() / 2, size_t(15));
 
   // Declares a default Aligner
   StripedSmithWaterman::Aligner aligner;
@@ -32,14 +31,14 @@ int main() {
   // Declares an alignment that stores the result
   StripedSmithWaterman::Alignment alignment;
   // Aligns the query to the ref
-  aligner.Align(query.c_str(), ref.c_str(), ref.size(), filter, &alignment, maskLen);
+  aligner.Align(query.c_str(), query.size(), ref.c_str(), ref.size(), filter, alignment, maskLen);
 
   PrintAlignment(alignment);
 
   return 0;
 }
 
-static void PrintAlignment(const StripedSmithWaterman::Alignment& alignment){
+static void PrintAlignment(const StripedSmithWaterman::Alignment& alignment) {
   cout << "===== SSW result =====" << endl;
   cout << "Best Smith-Waterman score:\t" << alignment.sw_score << endl
        << "Next-best Smith-Waterman score:\t" << alignment.sw_score_next_best << endl

--- a/src/ssw.h
+++ b/src/ssw.h
@@ -168,8 +168,8 @@ int32_t mark_mismatch (int32_t ref_begin1,
 	@param	op_letter	CIGAR operation character ('M', 'I', etc)
 	@return			32-bit unsigned integer, representing encoded CIGAR operation and length
 */
-static inline uint32_t to_cigar_int (uint32_t length, char op_letter) {
-	return (length << BAM_CIGAR_SHIFT) | (encoded_ops[(int)op_letter]);
+static inline uint32_t to_cigar_int (uint32_t length, unsigned char op_letter) {
+	return (length << BAM_CIGAR_SHIFT) | (encoded_ops[op_letter]);
 }
 
 /*!	@function		Extract CIGAR operation character from CIGAR 32-bit unsigned integer

--- a/src/ssw_cpp.cpp
+++ b/src/ssw_cpp.cpp
@@ -5,29 +5,26 @@
 #include "ssw_cpp.h"
 #include "ssw.h"
 
+#include <algorithm>
+#include <cassert>
+#include <cstring>
 #include <sstream>
 
+namespace StripedSmithWaterman {
 namespace {
 
-static const int8_t kBaseTranslation[128] = {
-    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
-    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
-    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
-    4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
-  //   A     C            G
-    4, 0, 4, 1,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 4, 4,
-  //             T
-    4, 4, 4, 4,  3, 0, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
-  //   a     c            g
-    4, 0, 4, 1,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 4, 4,
-  //             t
-    4, 4, 4, 4,  3, 0, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4
-};
+const int default_score_matrix_size = 5;
 
-void BuildSwScoreMatrix(const uint8_t& match_score,
-                        const uint8_t& mismatch_penalty,
-			int8_t* matrix) {
+const int8_t kBaseTranslation[128] = {
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    // A     C           G                                      T
+    4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+    // a     c           g                                      t
+    4, 0, 4, 1, 4, 4, 4, 2, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4};
 
+void BuildSwScoreMatrix(
+    const uint8_t match_score, const uint8_t mismatch_penalty, std::vector<int8_t>& matrix) {
   // The score matrix looks like
   //                 // A,  C,  G,  T,  N
   //  score_matrix_ = { 2, -2, -2, -2, -2, // A
@@ -39,54 +36,54 @@ void BuildSwScoreMatrix(const uint8_t& match_score,
   int id = 0;
   for (int i = 0; i < 4; ++i) {
     for (int j = 0; j < 4; ++j) {
-      matrix[id] = ((i == j) ? match_score : static_cast<int8_t>(-mismatch_penalty));
+      matrix[id] = ((i == j) ? match_score : -mismatch_penalty);
       ++id;
     }
-    matrix[id] = static_cast<int8_t>(-mismatch_penalty); // For N
+    matrix[id] = -mismatch_penalty;  // For N
     ++id;
   }
 
-  for (int i = 0; i < 5; ++i)
-    matrix[id++] = static_cast<int8_t>(-mismatch_penalty); // For N
-
+  for (int i = 0; i < 5; ++i) {
+    matrix[id] = -mismatch_penalty;  // For N
+    ++id;
+  }
 }
 
-void ConvertAlignment(const s_align& s_al,
-                      const int& query_len,
-                      StripedSmithWaterman::Alignment* al) {
-  al->sw_score           = s_al.score1;
-  al->sw_score_next_best = s_al.score2;
-  al->ref_begin          = s_al.ref_begin1;
-  al->ref_end            = s_al.ref_end1;
-  al->query_begin        = s_al.read_begin1;
-  al->query_end          = s_al.read_end1;
-  al->ref_end_next_best  = s_al.ref_end2;
-
-  al->cigar.clear();
-  al->cigar_string.clear();
+Alignment ConvertAlignment(const s_align& s_al, const int query_len) {
+  Alignment result;
+  result.sw_score           = s_al.score1;
+  result.sw_score_next_best = s_al.score2;
+  result.ref_begin          = s_al.ref_begin1;
+  result.ref_end            = s_al.ref_end1;
+  result.query_begin        = s_al.read_begin1;
+  result.query_end          = s_al.read_end1;
+  result.ref_end_next_best  = s_al.ref_end2;
 
   if (s_al.cigarLen > 0) {
     std::ostringstream cigar_string;
-    if (al->query_begin > 0) {
-      uint32_t cigar = to_cigar_int(al->query_begin, 'S');
-      al->cigar.push_back(cigar);
-      cigar_string << al->query_begin << 'S';
+    if (result.query_begin > 0) {
+      uint32_t cigar = to_cigar_int(result.query_begin, 'S');
+      result.cigar.push_back(cigar);
+      cigar_string << result.query_begin << 'S';
     }
 
     for (int i = 0; i < s_al.cigarLen; ++i) {
-      al->cigar.push_back(s_al.cigar[i]);
-      cigar_string << cigar_int_to_len(s_al.cigar[i]) << cigar_int_to_op(s_al.cigar[i]);
+      const uint32_t cigar_op = s_al.cigar[i];
+      result.cigar.push_back(cigar_op);
+      cigar_string << cigar_int_to_len(cigar_op) << cigar_int_to_op(cigar_op);
     }
 
-    int end = query_len - al->query_end - 1;
+    int end = query_len - result.query_end - 1;
     if (end > 0) {
       uint32_t cigar = to_cigar_int(end, 'S');
-      al->cigar.push_back(cigar);
+      result.cigar.push_back(cigar);
       cigar_string << end << 'S';
     }
 
-    al->cigar_string = cigar_string.str();
-  } // end if
+    result.cigar_string = cigar_string.str();
+  }  // end if
+
+  return result;
 }
 
 // @Function:
@@ -94,27 +91,27 @@ void ConvertAlignment(const s_align& s_al,
 //     and store it in new_cigar and new_cigar_string.
 //     Clean up in_M (false), in_X (false), length_M (0), and length_X(0).
 void CleanPreviousMOperator(
-    bool* in_M,
-    bool* in_X,
-    uint32_t* length_M,
-    uint32_t* length_X,
-    std::vector<uint32_t>* new_cigar,
-    std::ostringstream* new_cigar_string) {
-  if (*in_M) {
-    uint32_t match = to_cigar_int(*length_M, '=');
-    new_cigar->push_back(match);
-    (*new_cigar_string) << *length_M << '=';
-  } else if (*in_X){ //in_X
-    uint32_t match = to_cigar_int(*length_X, 'X');
-    new_cigar->push_back(match);
-    (*new_cigar_string) << *length_X << 'X';
+    bool&                  in_M,
+    bool&                  in_X,
+    uint32_t&              length_M,
+    uint32_t&              length_X,
+    std::vector<uint32_t>& new_cigar,
+    std::ostringstream&    new_cigar_string) {
+  if (in_M) {
+    uint32_t match = to_cigar_int(length_M, '=');
+    new_cigar.push_back(match);
+    new_cigar_string << length_M << '=';
+  } else if (in_X) {
+    uint32_t match = to_cigar_int(length_X, 'X');
+    new_cigar.push_back(match);
+    new_cigar_string << length_X << 'X';
   }
 
   // Clean up
-  *in_M = false;
-  *in_X = false;
-  *length_M = 0;
-  *length_X = 0;
+  in_M     = false;
+  in_X     = false;
+  length_M = 0;
+  length_X = 0;
 }
 
 // @Function:
@@ -124,294 +121,256 @@ void CleanPreviousMOperator(
 // @Return:
 //     The number of mismatches.
 int CalculateNumberMismatch(
-    StripedSmithWaterman::Alignment* al,
-    int8_t const *ref,
-    int8_t const *query,
-    const int& query_len) {
-
-  ref   += al->ref_begin;
-  query += al->query_begin;
+    Alignment& al, const int8_t* ref, const int8_t* query, const int query_len) {
+  ref += al.ref_begin;
+  query += al.query_begin;
   int mismatch_length = 0;
 
   std::vector<uint32_t> new_cigar;
-  std::ostringstream new_cigar_string;
+  std::ostringstream    new_cigar_string;
 
-  if (al->query_begin > 0) {
-    uint32_t cigar = to_cigar_int(al->query_begin, 'S');
+  if (al.query_begin > 0) {
+    uint32_t cigar = to_cigar_int(al.query_begin, 'S');
     new_cigar.push_back(cigar);
-    new_cigar_string << al->query_begin << 'S';
+    new_cigar_string << al.query_begin << 'S';
   }
 
-  bool in_M = false; // the previous is match
-  bool in_X = false; // the previous is mismatch
+  bool     in_M     = false;  // the previous is match
+  bool     in_X     = false;  // the previous is mismatch
   uint32_t length_M = 0;
   uint32_t length_X = 0;
 
-  for (unsigned int i = 0; i < al->cigar.size(); ++i) {
-    char op = cigar_int_to_op(al->cigar[i]);
-    uint32_t length = cigar_int_to_len(al->cigar[i]);
+  for (std::vector<uint32_t>::const_iterator cigar_op_it     = al.cigar.begin(),
+                                             cigar_op_it_end = al.cigar.end();
+       cigar_op_it != cigar_op_it_end; ++cigar_op_it) {
+    const uint32_t cigar_op = *cigar_op_it;
+    char           op       = cigar_int_to_op(cigar_op);
+    uint32_t       length   = cigar_int_to_len(cigar_op);
     if (op == 'M') {
       for (uint32_t j = 0; j < length; ++j) {
-	if (*ref != *query) {
-	  ++mismatch_length;
-          if (in_M) { // the previous is match; however the current one is mismatche
-	    uint32_t match = to_cigar_int(length_M, '=');
-	    new_cigar.push_back(match);
-	    new_cigar_string << length_M << '=';
-	  }
-	  length_M = 0;
-	  ++length_X;
-	  in_M = false;
-	  in_X = true;
-	} else { // *ref == *query
-	  if (in_X) { // the previous is mismatch; however the current one is matche
-	    uint32_t match = to_cigar_int(length_X, 'X');
-	    new_cigar.push_back(match);
-	    new_cigar_string << length_X << 'X';
-	  }
-	  ++length_M;
-	  length_X = 0;
-	  in_M = true;
-	  in_X = false;
-	} // end of if (*ref != *query)
-	++ref;
-	++query;
+        if (*ref != *query) {
+          ++mismatch_length;
+          if (in_M) {  // the previous is match; however the current one is mismatched
+            uint32_t match = to_cigar_int(length_M, '=');
+            new_cigar.push_back(match);
+            new_cigar_string << length_M << '=';
+          }
+          length_M = 0;
+          ++length_X;
+          in_M = false;
+          in_X = true;
+        } else {       // *ref == *query
+          if (in_X) {  // the previous is mismatch; however the current one is matched
+            uint32_t match = to_cigar_int(length_X, 'X');
+            new_cigar.push_back(match);
+            new_cigar_string << length_X << 'X';
+          }
+          ++length_M;
+          length_X = 0;
+          in_M     = true;
+          in_X     = false;
+        }  // end of if (*ref != *query)
+        ++ref;
+        ++query;
       }
     } else if (op == 'I') {
       query += length;
       mismatch_length += length;
-      CleanPreviousMOperator(&in_M, &in_X, &length_M, &length_X, &new_cigar, &new_cigar_string);
-      new_cigar.push_back(al->cigar[i]);
+      CleanPreviousMOperator(in_M, in_X, length_M, length_X, new_cigar, new_cigar_string);
+      new_cigar.push_back(cigar_op);
       new_cigar_string << length << 'I';
     } else if (op == 'D') {
       ref += length;
       mismatch_length += length;
-      CleanPreviousMOperator(&in_M, &in_X, &length_M, &length_X, &new_cigar, &new_cigar_string);
-      new_cigar.push_back(al->cigar[i]);
+      CleanPreviousMOperator(in_M, in_X, length_M, length_X, new_cigar, new_cigar_string);
+      new_cigar.push_back(cigar_op);
       new_cigar_string << length << 'D';
     }
   }
 
-  CleanPreviousMOperator(&in_M, &in_X, &length_M, &length_X, &new_cigar, &new_cigar_string);
+  CleanPreviousMOperator(in_M, in_X, length_M, length_X, new_cigar, new_cigar_string);
 
-  int end = query_len - al->query_end - 1;
+  int end = query_len - al.query_end - 1;
   if (end > 0) {
     uint32_t cigar = to_cigar_int(end, 'S');
     new_cigar.push_back(cigar);
     new_cigar_string << end << 'S';
   }
 
-  al->cigar_string.clear();
-  al->cigar.clear();
-  al->cigar_string = new_cigar_string.str();
-  al->cigar = new_cigar;
+  al.cigar_string = new_cigar_string.str();
+  al.cigar.swap(new_cigar);
 
   return mismatch_length;
 }
 
-void SetFlag(const StripedSmithWaterman::Filter& filter, uint8_t* flag) {
-  if (filter.report_begin_position) *flag |= 0x08;
-  if (filter.report_cigar) *flag |= 0x0f;
+void SetFlag(const Filter& filter, uint8_t& flag) {
+  if (filter.report_begin_position) {
+    flag |= 0x08;
+  }
+  if (filter.report_cigar) {
+    flag |= 0x0f;
+  }
 }
 
-// http://www.cplusplus.com/faq/sequences/arrays/sizeof-array/#cpp
-template <typename T, size_t N>
-inline size_t SizeOfArray( const T(&)[ N ] )
-{
-  return N;
-}
+}  // namespace
 
-} // namespace
-
-
-
-namespace StripedSmithWaterman {
-
-Aligner::Aligner(void)
-    : score_matrix_(NULL)
-    , score_matrix_size_(5)
-    , translation_matrix_(NULL)
-    , match_score_(2)
-    , mismatch_penalty_(2)
-    , gap_opening_penalty_(3)
-    , gap_extending_penalty_(1)
-    , translated_reference_(NULL)
-    , reference_length_(0)
-{
+Aligner::Aligner()
+    : score_matrix_size_(default_score_matrix_size) {
   BuildDefaultMatrix();
 }
 
 Aligner::Aligner(
-    const uint8_t& match_score,
-    const uint8_t& mismatch_penalty,
-    const uint8_t& gap_opening_penalty,
-    const uint8_t& gap_extending_penalty)
-
-    : score_matrix_(NULL)
-    , score_matrix_size_(5)
-    , translation_matrix_(NULL)
-    , match_score_(match_score)
-    , mismatch_penalty_(mismatch_penalty)
-    , gap_opening_penalty_(gap_opening_penalty)
-    , gap_extending_penalty_(gap_extending_penalty)
-    , translated_reference_(NULL)
-    , reference_length_(0)
-{
+    const uint8_t match_score,
+    const uint8_t mismatch_penalty,
+    const uint8_t gap_opening_penalty,
+    const uint8_t gap_extending_penalty)
+    : p_(match_score, mismatch_penalty, gap_opening_penalty, gap_extending_penalty)
+    , score_matrix_size_(default_score_matrix_size) {
   BuildDefaultMatrix();
 }
 
-Aligner::Aligner(const int8_t* score_matrix,
-                 const int&    score_matrix_size,
-	         const int8_t* translation_matrix,
-		 const int&    translation_matrix_size)
+Aligner::Aligner(
+    const int8_t* score_matrix,
+    const int     score_matrix_size,
+    const int8_t* translation_matrix,
+    const int     translation_matrix_size)
+    : score_matrix_size_(score_matrix_size)
+    , score_matrix_(score_matrix, score_matrix + score_matrix_size_ * score_matrix_size_)
+    , translation_matrix_(translation_matrix, translation_matrix + translation_matrix_size) {}
 
-    : score_matrix_(NULL)
-    , score_matrix_size_(score_matrix_size)
-    , translation_matrix_(NULL)
-    , match_score_(2)
-    , mismatch_penalty_(2)
-    , gap_opening_penalty_(3)
-    , gap_extending_penalty_(1)
-    , translated_reference_(NULL)
-    , reference_length_(0)
-{
-  score_matrix_ = new int8_t[score_matrix_size_ * score_matrix_size_];
-  memcpy(score_matrix_, score_matrix, sizeof(int8_t) * score_matrix_size_ * score_matrix_size_);
-  translation_matrix_ = new int8_t[translation_matrix_size];
-  memcpy(translation_matrix_, translation_matrix, sizeof(int8_t) * translation_matrix_size);
-}
-
-
-Aligner::~Aligner(void){
-  Clear();
-}
-
-int Aligner::SetReferenceSequence(const char* seq, const int& length) {
-
-  int len = 0;
-  if (translation_matrix_) {
-    // delete the current buffer
-    CleanReferenceSequence();
-    // allocate a new buffer
-    translated_reference_ = new int8_t[length];
-
-    len = TranslateBase(seq, length, translated_reference_);
-  } else {
-    // nothing
+size_t Aligner::SetReferenceSequence(const char* const ref, const size_t ref_len) {
+  ClearReferenceSequence();
+  if (!translation_matrix_.empty()) {
+    translated_reference_ = TranslateBase(ref, ref_len);
   }
 
-  reference_length_ = len;
-  return len;
+  return translated_reference_.size();
 }
 
-int Aligner::TranslateBase(const char* bases, const int& length,
-    int8_t* translated) const {
+size_t Aligner::SetReferenceSequence(const char* const ref) {
+  return SetReferenceSequence(ref, std::strlen(ref));
+}
 
-  const char* ptr = bases;
-  int len = 0;
-  for (int i = 0; i < length; ++i) {
-    translated[i] = translation_matrix_[(int) *ptr];
-    ++ptr;
-    ++len;
+void Aligner::ClearReferenceSequence() { translated_reference_.clear(); }
+
+void Aligner::SetGapPenalty(const uint8_t opening, const uint8_t extending) {
+  p_.gap_opening_penalty_   = opening;
+  p_.gap_extending_penalty_ = extending;
+}
+
+std::vector<int8_t> Aligner::TranslateBase(const char* const str, const size_t str_len) const {
+  assert(!translation_matrix_.empty());
+  std::vector<int8_t> result;
+  result.reserve(str_len);
+  for (size_t i = 0; i < str_len; ++i) {
+    result.push_back(translation_matrix_[static_cast<unsigned char>(str[i])]);
+  }
+  return result;
+}
+
+uint16_t Aligner::Align(
+    const char* const query,
+    const size_t      query_len,
+    const Filter&     filter,
+    Alignment&        alignment,
+    int32_t           maskLen) const {
+  if (translated_reference_.empty() || (query_len == 0)) {
+    return false;
   }
 
-  return len;
+  return AlignImpl(query, query_len, translated_reference_, filter, alignment, maskLen);
 }
 
+uint16_t Aligner::Align(
+    const char* const query,
+    const Filter&     filter,
+    Alignment&        alignment,
+    const int32_t     maskLen) const {
+  return Align(query, std::strlen(query), filter, alignment, maskLen);
+}
 
-uint16_t Aligner::Align(const char* query, const Filter& filter,
-                    Alignment* alignment, const int32_t maskLen) const
-{
-  if (!translation_matrix_) return false;
-  if (reference_length_ == 0) return false;
+uint16_t Aligner::Align(
+    const char* const query,
+    const size_t      query_len,
+    const char* const ref,
+    const size_t      ref_len,
+    const Filter&     filter,
+    Alignment&        alignment,
+    int32_t           maskLen) const {
+  if (translation_matrix_.empty() || (ref_len == 0) || (query_len == 0)) {
+    return false;
+  }
 
-  int query_len = strlen(query);
-  if (query_len == 0) return false;
-  int8_t* translated_query = new int8_t[query_len];
-  TranslateBase(query, query_len, translated_query);
+  const std::vector<int8_t> translated_ref(TranslateBase(ref, ref_len));
+  assert(translated_ref.size() == ref_len);
+
+  return AlignImpl(query, query_len, translated_ref, filter, alignment, maskLen);
+}
+
+uint16_t Aligner::Align(
+    const char* const query,
+    const char* const ref,
+    const Filter&     filter,
+    Alignment&        alignment,
+    const int32_t     maskLen) const {
+  return Align(query, std::strlen(query), ref, std::strlen(ref), filter, alignment, maskLen);
+}
+
+uint16_t Aligner::AlignImpl(
+    const char* const          query,
+    const size_t               query_len,
+    const std::vector<int8_t>& translated_ref,
+    const Filter&              filter,
+    Alignment&                 alignment,
+    int32_t                    maskLen) const {
+  if (translation_matrix_.empty()) {
+    return false;
+  }
+
+  maskLen = std::max(maskLen, 15);
+
+  const std::vector<int8_t> translated_query(TranslateBase(query, query_len));
+  assert(translated_query.size() == query_len);
 
   const int8_t score_size = 2;
-  s_profile* profile = ssw_init(translated_query, query_len, score_matrix_,
-                                score_matrix_size_, score_size);
+  s_profile*   profile    = ssw_init(
+      translated_query.data(), translated_query.size(), score_matrix_.data(), score_matrix_size_,
+      score_size);
 
   uint8_t flag = 0;
-  SetFlag(filter, &flag);
-  s_align* s_al = ssw_align(profile, translated_reference_, reference_length_,
-                                 static_cast<int>(gap_opening_penalty_),
-				 static_cast<int>(gap_extending_penalty_),
-				 flag, filter.score_filter, filter.distance_filter, maskLen);
+  SetFlag(filter, flag);
+  s_align* s_al = ssw_align(
+      profile, translated_ref.data(), translated_ref.size(),
+      static_cast<int>(p_.gap_opening_penalty_), static_cast<int>(p_.gap_extending_penalty_), flag,
+      filter.score_filter, filter.distance_filter, maskLen);
 
-  alignment->Clear();
-  ConvertAlignment(*s_al, query_len, alignment);
-  alignment->mismatches = CalculateNumberMismatch(&*alignment, translated_reference_, translated_query, query_len);
+  alignment            = ConvertAlignment(*s_al, translated_query.size());
+  alignment.mismatches = CalculateNumberMismatch(
+      alignment, translated_ref.data(), translated_query.data(), translated_query.size());
   uint16_t align_flag = s_al->flag;
 
   // Free memory
-  delete [] translated_query;
   align_destroy(s_al);
   init_destroy(profile);
 
   return align_flag;
 }
 
-
-uint16_t Aligner::Align(const char* query, const char* ref, const int& ref_len,
-                    const Filter& filter, Alignment* alignment, const int32_t maskLen) const
-{
-  if (!translation_matrix_) return false;
-
-  int query_len = strlen(query);
-  if (query_len == 0) return false;
-  int8_t* translated_query = new int8_t[query_len];
-  TranslateBase(query, query_len, translated_query);
-
-  // calculate the valid length
-  int valid_ref_len = ref_len;
-  int8_t* translated_ref = new int8_t[valid_ref_len];
-  TranslateBase(ref, valid_ref_len, translated_ref);
-
-
-  const int8_t score_size = 2;
-  s_profile* profile = ssw_init(translated_query, query_len, score_matrix_,
-                                score_matrix_size_, score_size);
-
-  uint8_t flag = 0;
-  SetFlag(filter, &flag);
-  s_align* s_al = ssw_align(profile, translated_ref, valid_ref_len,
-                                 static_cast<int>(gap_opening_penalty_),
-				 static_cast<int>(gap_extending_penalty_),
-				 flag, filter.score_filter, filter.distance_filter, maskLen);
-
-  alignment->Clear();
-  ConvertAlignment(*s_al, query_len, alignment);
-  alignment->mismatches = CalculateNumberMismatch(&*alignment, translated_ref, translated_query, query_len);
-  uint16_t align_flag = s_al->flag;
-
-  // Free memory
-  delete [] translated_query;
-  delete [] translated_ref;
-  align_destroy(s_al);
-  init_destroy(profile);
-
-  return align_flag;
-}
-
-void Aligner::Clear(void) {
+void Aligner::Clear() {
   ClearMatrices();
-  CleanReferenceSequence();
+  ClearReferenceSequence();
 }
 
-void Aligner::SetAllDefault(void) {
-  score_matrix_size_     = 5;
-  match_score_           = 2;
-  mismatch_penalty_      = 2;
-  gap_opening_penalty_   = 3;
-  gap_extending_penalty_ = 1;
-  reference_length_      = 0;
+void Aligner::SetAllDefault() {
+  p_                 = Parameters();
+  score_matrix_size_ = default_score_matrix_size;
+  translated_reference_.clear();
 }
 
-bool Aligner::ReBuild(void) {
-  if (translation_matrix_) return false;
+bool Aligner::ReBuild() {
+  if (!translation_matrix_.empty()) {
+    return false;
+  }
 
   SetAllDefault();
   BuildDefaultMatrix();
@@ -420,18 +379,17 @@ bool Aligner::ReBuild(void) {
 }
 
 bool Aligner::ReBuild(
-    const uint8_t& match_score,
-    const uint8_t& mismatch_penalty,
-    const uint8_t& gap_opening_penalty,
-    const uint8_t& gap_extending_penalty) {
-  if (translation_matrix_) return false;
+    const uint8_t match_score,
+    const uint8_t mismatch_penalty,
+    const uint8_t gap_opening_penalty,
+    const uint8_t gap_extending_penalty) {
+  if (!translation_matrix_.empty()) {
+    return false;
+  }
 
   SetAllDefault();
 
-  match_score_           = match_score;
-  mismatch_penalty_      = mismatch_penalty;
-  gap_opening_penalty_   = gap_opening_penalty;
-  gap_extending_penalty_ = gap_extending_penalty;
+  p_ = Parameters(match_score, mismatch_penalty, gap_opening_penalty, gap_extending_penalty);
 
   BuildDefaultMatrix();
 
@@ -440,32 +398,25 @@ bool Aligner::ReBuild(
 
 bool Aligner::ReBuild(
     const int8_t* score_matrix,
-    const int&    score_matrix_size,
+    const int     score_matrix_size,
     const int8_t* translation_matrix,
-    const int&    translation_matrix_size) {
-
-  ClearMatrices();
-  score_matrix_ = new int8_t[score_matrix_size_ * score_matrix_size_];
-  memcpy(score_matrix_, score_matrix, sizeof(int8_t) * score_matrix_size_ * score_matrix_size_);
-  translation_matrix_ = new int8_t[translation_matrix_size];
-  memcpy(translation_matrix_, translation_matrix, sizeof(int8_t) * translation_matrix_size);
+    const int     translation_matrix_size) {
+  score_matrix_size_ = score_matrix_size;
+  score_matrix_.assign(score_matrix, score_matrix + score_matrix_size_ * score_matrix_size_);
+  translation_matrix_.assign(translation_matrix, translation_matrix + translation_matrix_size);
 
   return true;
 }
 
-void Aligner::BuildDefaultMatrix(void) {
-  ClearMatrices();
-  score_matrix_ = new int8_t[score_matrix_size_ * score_matrix_size_];
-  BuildSwScoreMatrix(match_score_, mismatch_penalty_, score_matrix_);
-  translation_matrix_ = new int8_t[SizeOfArray(kBaseTranslation)];
-  memcpy(translation_matrix_, kBaseTranslation, sizeof(int8_t) * SizeOfArray(kBaseTranslation));
+void Aligner::BuildDefaultMatrix() {
+  score_matrix_.resize(score_matrix_size_ * score_matrix_size_);
+  BuildSwScoreMatrix(p_.match_score_, p_.mismatch_penalty_, score_matrix_);
+  translation_matrix_.assign(kBaseTranslation, kBaseTranslation + sizeof(kBaseTranslation));
 }
 
-void Aligner::ClearMatrices(void) {
-  delete [] score_matrix_;
-  score_matrix_ = NULL;
-
-  delete [] translation_matrix_;
-  translation_matrix_ = NULL;
+void Aligner::ClearMatrices() {
+  score_matrix_.clear();
+  translation_matrix_.clear();
 }
-} // namespace StripedSmithWaterman
+
+}  // namespace StripedSmithWaterman

--- a/src/ssw_cpp.h
+++ b/src/ssw_cpp.h
@@ -5,6 +5,7 @@
 #ifndef COMPLETE_STRIPED_SMITH_WATERMAN_CPP_H_
 #define COMPLETE_STRIPED_SMITH_WATERMAN_CPP_H_
 
+#include <stddef.h>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -12,30 +13,28 @@
 namespace StripedSmithWaterman {
 
 struct Alignment {
-  uint16_t sw_score;           // The best alignment score
-  uint16_t sw_score_next_best; // The next best alignment score
-  int32_t  ref_begin;          // Reference begin position of the best alignment
-  int32_t  ref_end;            // Reference end position of the best alignment
-  int32_t  query_begin;        // Query begin position of the best alignment
-  int32_t  query_end;          // Query end position of the best alignment
-  int32_t  ref_end_next_best;  // Reference end position of the next best alignment
-  int32_t  mismatches;         // Number of mismatches of the alignment
-  std::string cigar_string;    // Cigar string of the best alignment
-  std::vector<uint32_t> cigar; // Cigar stored in the BAM format
-                               //   high 28 bits: length
-			       //   low 4 bits: M/I/D/S/X (0/1/2/4/8);
-  void Clear() {
-    sw_score           = 0;
-    sw_score_next_best = 0;
-    ref_begin          = 0;
-    ref_end            = 0;
-    query_begin        = 0;
-    query_end          = 0;
-    ref_end_next_best  = 0;
-    mismatches         = 0;
-    cigar_string.clear();
-    cigar.clear();
-  };
+  uint16_t    sw_score;            // The best alignment score
+  uint16_t    sw_score_next_best;  // The next best alignment score
+  int32_t     ref_begin;           // Reference begin position of the best alignment
+  int32_t     ref_end;             // Reference end position of the best alignment
+  int32_t     query_begin;         // Query begin position of the best alignment
+  int32_t     query_end;           // Query end position of the best alignment
+  int32_t     ref_end_next_best;   // Reference end position of the next best alignment
+  int32_t     mismatches;          // Number of mismatches of the alignment
+  std::string cigar_string;        // Cigar string of the best alignment
+                                   // Cigar stored in the BAM format
+                                   //   high 28 bits: length
+  std::vector<uint32_t> cigar;     //   low 4 bits: M/I/D/S/X (0/1/2/4/8);
+
+  Alignment()
+      : sw_score(0)
+      , sw_score_next_best(0)
+      , ref_begin(0)
+      , ref_end(0)
+      , query_begin(0)
+      , query_end(0)
+      , ref_end_next_best(0)
+      , mismatches(0) {}
 };
 
 struct Filter {
@@ -44,128 +43,158 @@ struct Filter {
   // NOTE: Only need score of alignments, please set 'report_begin_position'
   //       and 'report_cigar' false.
 
-  bool report_begin_position;    // Give ref_begin and query_begin.
-                                 //   If it is not set, ref_begin and query_begin are -1.
-  bool report_cigar;             // Give cigar_string and cigar.
-                                 //   report_begin_position is automatically TRUE.
+  bool report_begin_position;  // Give ref_begin and query_begin.
+                               //   If it is not set, ref_begin and query_begin are -1.
+  bool report_cigar;           // Give cigar_string and cigar.
+                               //   report_begin_position is automatically TRUE.
 
   // When *report_cigar* is true and alignment passes these two filters,
   //   cigar_string and cigar will be given.
-  uint16_t score_filter;         // score >= score_filter
-  uint16_t distance_filter;      // ((ref_end - ref_begin) < distance_filter) &&
-                                 // ((query_end - read_begin) < distance_filter)
+  uint16_t score_filter;     // score >= score_filter
+  uint16_t distance_filter;  // ((ref_end - ref_begin) < distance_filter) &&
+
+  // ((query_end - read_begin) < distance_filter)
 
   Filter()
-    : report_begin_position(true)
-    , report_cigar(true)
-    , score_filter(0)
-    , distance_filter(32767)
-  {};
-
-  Filter(const bool& pos, const bool& cigar, const uint16_t& score, const uint16_t& dis)
-    : report_begin_position(pos)
-    , report_cigar(cigar)
-    , score_filter(score)
-    , distance_filter(dis)
-    {};
+      : report_begin_position(true)
+      , report_cigar(true)
+      , score_filter(0)
+      , distance_filter(32767) {}
 };
 
 class Aligner {
- public:
+public:
   // =========
   // @function Construct an Aligner on default values.
-  //             The function will build the {A.C,G,T,N} aligner.
+  //             The function will build the {A,C,G,T,N} aligner.
   //             If you target for other character aligners, then please
   //             use the other constructor and pass the corresponding matrix in.
   // =========
-  Aligner(void);
+  Aligner();
 
   // =========
   // @function Construct an Aligner by assigning scores.
-  //             The function will build the {A.C,G,T,N} aligner.
+  //             The function will build the {A,C,G,T,N} aligner.
   //             If you target for other character aligners, then please
   //             use the other constructor and pass the corresponding matrix in.
   // =========
-  Aligner(const uint8_t& match_score,
-          const uint8_t& mismatch_penalty,
-	  const uint8_t& gap_opening_penalty,
-	  const uint8_t& gap_extending_penalty);
+  Aligner(
+      uint8_t match_score,
+      uint8_t mismatch_penalty,
+      uint8_t gap_opening_penalty,
+      uint8_t gap_extending_penalty);
 
   // =========
-  // @function Construct an Aligner by the specific matrixs.
+  // @function Construct an Aligner by the specific matrices.
   // =========
-  Aligner(const int8_t* score_matrix,
-          const int&    score_matrix_size,
-          const int8_t* translation_matrix,
-	  const int&    translation_matrix_size);
-
-  ~Aligner(void);
+  Aligner(
+      const int8_t* score_matrix,
+      int           score_matrix_size,
+      const int8_t* translation_matrix,
+      int           translation_matrix_size);
 
   // =========
   // @function Build the reference sequence and thus make
-  //             Align(const char* query, s_align* alignment) function;
+  //             Align(const char* query, size_t query_len, const Filter&
+  //             filter, Alignment& alignment, int32_t maskLen) function;
   //             otherwise the reference should be given when aligning.
   //           [NOTICE] If there exists a sequence, that one will be deleted
   //                    and replaced.
-  // @param    seq    The reference bases;
-  //                  [NOTICE] It is not necessary null terminated.
-  // @param    length The length of bases will be built.
+  // @param    ref     The reference bases;
+  //                   [NOTICE] Does not have to be null terminated.
+  // @param    ref_len The number of bases in ref.
   // @return   The length of the built bases.
   // =========
-  int SetReferenceSequence(const char* seq, const int& length);
+  size_t SetReferenceSequence(const char* ref, size_t ref_len);
 
-  void CleanReferenceSequence(void);
+  // =========
+  // @function Like SetReferenceSequence(const char* ref, size_t ref_len), but
+  // requires null-terminated ref.
+  // =========
+  size_t SetReferenceSequence(const char* ref);
+
+  void ClearReferenceSequence();
 
   // =========
   // @function Set penalties for opening and extending gaps
   //           [NOTICE] The defaults are 3 and 1 respectively.
   // =========
-  void SetGapPenalty(const uint8_t& opening, const uint8_t& extending) {
-    gap_opening_penalty_ = opening;
-    gap_extending_penalty_ = extending;
-  };
+  void SetGapPenalty(uint8_t opening, uint8_t extending);
 
   // =========
-  // @function Align the query againt the reference that is set by
-  //             SetReferenceSequence.
+  // @function Align the query against the reference set by SetReferenceSequence.
   // @param    query     The query sequence.
+  //                     [NOTICE] Does not have to be null terminated.
+  // @param    query_len The number of bases in query.
   // @param    filter    The filter for the alignment.
   // @param    alignment The container contains the result.
-  // @param    maskLen   The distance between the optimal and suboptimal alignment ending position will >= maskLen. We suggest to 
-  //                     use readLen/2, if you don't have special concerns. Note: maskLen has to be >= 15, otherwise this function 
+  // @param    maskLen   The distance between the optimal and suboptimal alignment ending position will >= maskLen. We suggest to
+  //                     use query_len/2, if you don't have special concerns. Note: maskLen has to be >= 15, otherwise this function
   //                     will NOT return the suboptimal alignment information.
+  //                     If the value is not provided, it will default to 15.
   // @return   If the alignment path is accurate (or has missing part). 0: accurate; 1: banded_sw is totally failed; 2: banded_sw returned path has missing part
   // =========
-  uint16_t Align(const char* query, const Filter& filter, Alignment* alignment, const int32_t maskLen) const;
+  uint16_t Align(
+      const char*   query,
+      size_t        query_len,
+      const Filter& filter,
+      Alignment&    alignment,
+      int32_t       maskLen = 0) const;
 
   // =========
-  // @function Align the query againt the reference.
-  //           [NOTICE] The reference won't replace the reference
-  //                      set by SetReferenceSequence.
+  // @function Like Align(const char* query, size_t query_len, ...), but
+  // requires null-terminated query.
+  // =========
+  uint16_t Align(
+      const char* query, const Filter& filter, Alignment& alignment, int32_t maskLen = 0) const;
+
+  // =========
+  // @function Align the query against the reference.
+  //           [NOTICE] The reference won't replace the reference set by SetReferenceSequence.
   // @param    query     The query sequence.
+  //                     [NOTICE] Does not have to be null terminated.
+  // @param    query_len The number of bases in query.
   // @param    ref       The reference sequence.
-  //                     [NOTICE] It is not necessary null terminated.
-  // @param    ref_len   The length of the reference sequence.
+  //                     [NOTICE] Does not have to be null terminated.
+  // @param    ref_len   The number of bases in ref.
   // @param    filter    The filter for the alignment.
   // @param    alignment The container contains the result.
-  // @param    maskLen   The distance between the optimal and suboptimal alignment ending position will >= maskLen. We suggest to 
-  //                     use readLen/2, if you don't have special concerns. Note: maskLen has to be >= 15, otherwise this function 
+  // @param    maskLen   The distance between the optimal and suboptimal alignment ending position will >= maskLen. We suggest to
+  //                     use query_len/2, if you don't have special concerns. Note: maskLen has to be >= 15, otherwise this function
   //                     will NOT return the suboptimal alignment information.
+  //                     If the value is not provided, it will default to 15.
   // @return   If the alignment path is accurate (or has missing part). 0: accurate; 1: banded_sw is totally failed; 2: banded_sw returned path has missing part
   // =========
-  uint16_t Align(const char* query, const char* ref, const int& ref_len,
-             const Filter& filter, Alignment* alignment, const int32_t maskLen) const;
+  uint16_t Align(
+      const char*   query,
+      size_t        query_len,
+      const char*   ref,
+      size_t        ref_len,
+      const Filter& filter,
+      Alignment&    alignment,
+      int32_t       maskLen = 0) const;
+
+  // =========
+  // @function Like Align(const char* query, size_t query_len, const char* ref,
+  // size_t ref_len, ...), but requires null-terminated query and ref.
+  // =========
+  uint16_t Align(
+      const char*   query,
+      const char*   ref,
+      const Filter& filter,
+      Alignment&    alignment,
+      int32_t       maskLen = 0) const;
 
   // @function Clear up all containers and thus the aligner is disabled.
   //             To rebuild the aligner please use Build functions.
-  void Clear(void);
+  void Clear();
 
   // =========
   // @function Rebuild the aligner's ability on default values.
   //           [NOTICE] If the aligner is not cleaned, rebuilding will fail.
   // @return   True: succeed; false: fail.
   // =========
-  bool ReBuild(void);
+  bool ReBuild();
 
   // =========
   // @function Rebuild the aligner's ability by the specific matrixs.
@@ -173,10 +202,10 @@ class Aligner {
   // @return   True: succeed; false: fail.
   // =========
   bool ReBuild(
-          const uint8_t& match_score,
-          const uint8_t& mismatch_penalty,
-	  const uint8_t& gap_opening_penalty,
-	  const uint8_t& gap_extending_penalty);
+      uint8_t match_score,
+      uint8_t mismatch_penalty,
+      uint8_t gap_opening_penalty,
+      uint8_t gap_extending_penalty);
 
   // =========
   // @function Construct an Aligner by the specific matrixs.
@@ -184,46 +213,52 @@ class Aligner {
   // @return   True: succeed; false: fail.
   // =========
   bool ReBuild(
-          const int8_t* score_matrix,
-          const int&    score_matrix_size,
-          const int8_t* translation_matrix,
-	  const int&    translation_matrix_size);
+      const int8_t* score_matrix,
+      int           score_matrix_size,
+      const int8_t* translation_matrix,
+      int           translation_matrix_size);
 
- private:
-  int8_t* score_matrix_;
-  int     score_matrix_size_;
-  int8_t* translation_matrix_;
+private:
+  uint16_t AlignImpl(
+      const char* const          query,
+      const size_t               query_len,
+      const std::vector<int8_t>& translated_ref,
+      const Filter&              filter,
+      Alignment&                 alignment,
+      int32_t                    maskLen) const;
 
-  uint8_t match_score_;           // default: 2
-  uint8_t mismatch_penalty_;      // default: 2
-  uint8_t gap_opening_penalty_;   // default: 3
-  uint8_t gap_extending_penalty_; // default: 1
+  std::vector<int8_t> TranslateBase(const char* str, size_t strLen) const;
 
-  int8_t* translated_reference_;
-  int32_t reference_length_;
+  void SetAllDefault();
 
-  int TranslateBase(const char* bases, const int& length, int8_t* translated) const;
-  void SetAllDefault(void);
-  void BuildDefaultMatrix(void);
-  void ClearMatrices(void);
+  void BuildDefaultMatrix();
 
-  Aligner& operator= (const Aligner&);
-  Aligner (const Aligner&);
-}; // class Aligner
+  void ClearMatrices();
 
+private:
+  struct Parameters {
+    Parameters(
+        uint8_t match_score           = 2,
+        uint8_t mismatch_penalty      = 2,
+        uint8_t gap_opening_penalty   = 3,
+        uint8_t gap_extending_penalty = 1)
+        : match_score_(match_score)
+        , mismatch_penalty_(mismatch_penalty)
+        , gap_opening_penalty_(gap_opening_penalty)
+        , gap_extending_penalty_(gap_extending_penalty) {}
 
-// ================
-// inline functions
-// ================
-inline void Aligner::CleanReferenceSequence(void) {
-  if (reference_length_ == 0) return;
+    uint8_t match_score_;
+    uint8_t mismatch_penalty_;
+    uint8_t gap_opening_penalty_;
+    uint8_t gap_extending_penalty_;
+  } p_;
 
-  // delete the current buffer
-  if (reference_length_ > 1) delete [] translated_reference_;
-  else delete translated_reference_;
+  int                 score_matrix_size_;
+  std::vector<int8_t> score_matrix_;
+  std::vector<int8_t> translation_matrix_;
+  std::vector<int8_t> translated_reference_;
+};  // class Aligner
 
-  reference_length_ = 0;
-}
-} // namespace StripedSmithWaterman
+}  // namespace StripedSmithWaterman
 
-#endif // COMPLETE_STRIPED_SMITH_WATERMAN_CPP_H_
+#endif  // COMPLETE_STRIPED_SMITH_WATERMAN_CPP_H_


### PR DESCRIPTION
* Makefile should adhere to common Linux packaging conventions
* Allow using all APIs without calling `strlen()` internally
* Modernize to C++ code:
  * Avoid manual memory management with `new`/`delete` and use RAII types instead
  * Avoid passing pointers when references suffice
  * Avoid references for input values
  * Reduce code duplication in the `Align()` function